### PR TITLE
Use ResourceId to assert VMs

### DIFF
--- a/Assert-AutoShutdownSchedule.ps1
+++ b/Assert-AutoShutdownSchedule.ps1
@@ -157,12 +157,12 @@ function AssertVirtualMachinePowerState
     # Get VM depending on type
     if($VirtualMachine.ResourceType -eq "Microsoft.ClassicCompute/virtualMachines")
     {
-        $classicVM = $ClassicVMList | where Name -eq $VirtualMachine.Name
+        $classicVM = $ClassicVMList | where ResourceId -eq $VirtualMachine.ResourceId
         AssertClassicVirtualMachinePowerState -VirtualMachine $classicVM -DesiredState $DesiredState -Simulate $Simulate
     }
     elseif($VirtualMachine.ResourceType -eq "Microsoft.Compute/virtualMachines")
     {
-        $resourceManagerVM = $ResourceManagerVMList | where Name -eq $VirtualMachine.Name
+        $resourceManagerVM = $ResourceManagerVMList | where ResourceId -eq $VirtualMachine.ResourceId
         AssertResourceManagerVirtualMachinePowerState -VirtualMachine $resourceManagerVM -DesiredState $DesiredState -Simulate $Simulate
     }
     else


### PR DESCRIPTION
VM names do not have to be unique across resource groups. If that's the case, scripts fails. This is fixed by filtering on ResourceId instead.
